### PR TITLE
[EddystoneObserver] Fix usage of flexible arrays.

### DIFF
--- a/BLE_EddystoneObserver/source/main.cpp
+++ b/BLE_EddystoneObserver/source/main.cpp
@@ -91,7 +91,7 @@ void advertisementCallback(const Gap::AdvertisementCallbackParams_t *params)
     struct AdvertisingData_t {
         uint8_t                        length; /* doesn't include itself */
         GapAdvertisingData::DataType_t dataType;
-        uint8_t                        data[0];
+        uint8_t                        data[1];
     } AdvDataPacket;
 
     struct ApplicationData_t {


### PR DESCRIPTION
It is not authorized in C++ to use flexible arrays or arrays of zero length. 
While this is an extension enabled by ARMCC and GCC, this is not available from IAR.

This commit fix an invalid use of a flexible array in the EddystoneObserver example.
